### PR TITLE
speed up ExpiringMap::vacuum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,9 @@ impl<K: PartialEq + Eq + Hash, V> ExpiringMap<K, V> {
     pub fn vacuum(&mut self) {
         // keep all the items in the set where it has been
         // less than ttl since they were added
-        self.inner.retain(|_, expiry| expiry.not_expired());
+        let now = Instant::now();
+        self.inner
+            .retain(|_, expiry| now.duration_since(expiry.inserted) < expiry.ttl);
         if self.inner.len() > Self::MINIMUM_VACUUM_SIZE {
             self.last_size = self.inner.len();
         } else {


### PR DESCRIPTION
Using `not_expired` requires calling `elapsed` for every entry in the hashset, which requires a syscall.  By calling `duration_since`, we only have a single syscall regardless of how many entries are in the map.