### PR TITLE
Update `ExpiringMap::insert` to return the underlying value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ impl<K: PartialEq + Eq + Hash, V> ExpiringMap<K, V> {
     }
 
     /// Insert a value into the map, returning the old value if it has not expired and existed
-    pub fn insert(&mut self, key: K, value: V, ttl: Duration) -> Option<ExpiryValue<V>> {
+    pub fn insert(&mut self, key: K, value: V, ttl: Duration) -> Option<V> {
         self.vacuum_if_needed();
         let entry = ExpiryValue {
             inserted: Instant::now(),
@@ -185,6 +185,7 @@ impl<K: PartialEq + Eq + Hash, V> ExpiringMap<K, V> {
         self.inner
             .insert(key, entry)
             .filter(ExpiryValue::not_expired)
+            .map(ExpiryValue::value)
     }
 
     /// If this key exists and is not expired, returns true

--- a/src/test.rs
+++ b/src/test.rs
@@ -53,10 +53,7 @@ fn vacuum_sweeps() {
 fn insert_replace() {
     let mut m = ExpiringMap::new();
     m.insert("v", "x", Duration::from_secs(5));
-    assert_eq!(
-        m.insert("v", "y", Duration::from_secs(5)).unwrap().value,
-        "x"
-    );
+    assert_eq!(m.insert("v", "y", Duration::from_secs(5)).unwrap(), "x");
 }
 
 #[test]


### PR DESCRIPTION
This updates `ExpiringMap::insert` to work like the rest of the `ExpiringMap` functions that wrap the underlying `HashMap` implementation